### PR TITLE
fix: 使用force解决.gitignore和工作流冲突的问题

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,6 +125,10 @@ func main() {
 				if err != nil {
 					log.Fatal(err)
 				}
+				_, err = execCommand(ctx, workdir, "git", "add", "--force", ":/")
+				if err != nil {
+					log.Fatal(err)
+				}
 				// 判断是否有文件变动
 				out, err := execCommand(ctx, workdir, "git", "status", "-s")
 				if err != nil {
@@ -132,10 +136,6 @@ func main() {
 				}
 				if len(out) == 0 {
 					continue
-				}
-				_, err = execCommand(ctx, workdir, "git", "add", ":/")
-				if err != nil {
-					log.Fatal(err)
 				}
 				// 多个变动合并成一个提交
 				if changedBranches[workdir][branch] {


### PR DESCRIPTION
为了避免工作流的名字被.gitignore通配符匹配到
使用git add --force强制绕过.gitignore文件