### PR TITLE
fix: 提交时的消息不用添加双引号

### DIFF
--- a/main.go
+++ b/main.go
@@ -139,12 +139,12 @@ func main() {
 				}
 				// 多个变动合并成一个提交
 				if changedBranches[workdir][branch] {
-					_, err = execCommand(ctx, workdir, "git", "commit", "--amend", "-a", "-m", `"`+message+`"`)
+					_, err = execCommand(ctx, workdir, "git", "commit", "--amend", "-a", "-m", message)
 					if err != nil {
 						log.Fatal(err)
 					}
 				} else {
-					_, err = execCommand(ctx, workdir, "git", "commit", "-a", "-m", `"`+message+`"`)
+					_, err = execCommand(ctx, workdir, "git", "commit", "-a", "-m", message)
 					if err != nil {
 						log.Fatal(err)
 					}


### PR DESCRIPTION
golang的exec库会自动给参数添加双引号,避免空格等特殊字符导致参数被拆分